### PR TITLE
Update requirements, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
+# AI models
+ai-models/
+
 # Byte-compiled / optimized / DLL files
-__pycache__/
+**/__pycache__
 *.py[cod]
 *$py.class
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ uvicorn[standard]
 python-multipart
 pathlib
 bcrypt
-hashlib
 pydantic
-subprocess
+opencv-python
+opencv-contrib-python
+pytesseract
+pdf2image
+jinja2


### PR DESCRIPTION
- drop unused stuff from requirements.txt
- add more required stuff, such that `pip install -r requirements.txt` works
- we should probably add documentation on how to find and install the AI models
- fix .gitignore